### PR TITLE
Add Codex setup script

### DIFF
--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Use Python 3.11 for compatibility with ta-lib wheels
+if command -v pyenv >/dev/null; then
+    pyenv global 3.11.12
+fi
+
+# Install build dependencies
+apt-get update
+apt-get install -y gcc build-essential autoconf libtool pkg-config make wget git curl python3-dev python3-venv
+
+# Build and install the ta-lib C library
+cd build_helpers
+./install_ta-lib.sh
+cd ..
+
+# Symlink expected library name
+ln -sf /usr/local/lib/libta_lib.so /usr/local/lib/libta-lib.so
+
+# Create Python virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Environment variables to help build python ta-lib
+export TA_INCLUDE_PATH=/usr/local/include
+export TA_LIBRARY_PATH=/usr/local/lib
+
+pip install --upgrade pip setuptools wheel
+pip install ta-lib
+
+# Install freqtrade with hyperopt extras
+pip install -r requirements.txt -r requirements-hyperopt.txt
+pip install -e .
+
+# Validate installation
+freqtrade --version
+freqtrade backtesting --help >/dev/null
+freqtrade hyperopt --help >/dev/null
+
+echo "Freqtrade setup completed." 

--- a/docs/CODEX_SETUP.md
+++ b/docs/CODEX_SETUP.md
@@ -1,0 +1,27 @@
+# Codex Environment Setup
+
+This repository includes a helper script `codex_setup.sh` which installs Freqtrade and all dependencies required for backtesting and hyperopt.
+
+## Usage
+
+Run the script from the repository root:
+
+```bash
+./codex_setup.sh
+```
+
+The script performs the following steps:
+
+1. Installs system packages required to build dependencies.
+2. Builds and installs the TA-Lib C library.
+3. Creates a Python 3.11 virtual environment in `.venv`.
+4. Installs the `ta-lib` Python package and Freqtrade with hyperopt extras.
+5. Verifies the installation by running `freqtrade --version`, `freqtrade backtesting --help` and `freqtrade hyperopt --help`.
+
+After completion activate the environment with:
+
+```bash
+source .venv/bin/activate
+```
+
+You can then use all Freqtrade commands normally.


### PR DESCRIPTION
## Summary
- add `codex_setup.sh` to install Freqtrade with hyperopt and TA-Lib
- document how to run the script in `docs/CODEX_SETUP.md`

## Testing
- `./codex_setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_686a874883608331a4a3596ac0322c97